### PR TITLE
Add Jules self mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The **GPT Model** (`model`) option specifies which GPT model to use. You can fin
 
 The **Proxy configuration** (`proxyConfiguration`) option enables you to set proxies. The Web Agent will use these to prevent getting blocked by target websites. You can use both [Apify Proxy](https://apify.com/proxy) and custom HTTP or SOCKS5 proxy servers.
 
+**Jules self mode**
+
+Set `julesSelfMode` to `true` to run the agent in a simple self-adapting loop. The optional `julesIterations` field controls how many times the agent reuses its previous output as the next instruction.
+
 You can enter these either directly in [Apify Console](https://console.apify.com/) or programmatically in a JSON object using the [Apify API](https://apify.com/docs/api/v2#/reference/actors/run-collection/run-actor). Watch [this video](https://www.youtube.com/watch?v=ViYYDHSBAKM) to learn how get your data via the cURL command and with both Apify's API clients (Python and Node.js).  
 
 [AI Web Agent API](https://www.youtube.com/watch?v=ViYYDHSBAKM)

--- a/src/input.ts
+++ b/src/input.ts
@@ -8,4 +8,8 @@ export interface Input {
     proxyConfiguration?: ProxyConfigurationOptions;
     openaiApiKey?: string; // We can pass openaiApiKey as env variable locally
     model?: string;
+    /** When enabled the agent reruns in a simple self adapting loop. */
+    julesSelfMode?: boolean;
+    /** Number of iterations for the self mode. */
+    julesIterations?: number;
 }

--- a/src/jules_self_mode.ts
+++ b/src/jules_self_mode.ts
@@ -1,0 +1,24 @@
+import { webAgentLog } from './utils.js';
+import { WebAgentExecutor } from './agent_executor.js';
+
+/**
+ * Runs the WebAgentExecutor in "Jules self mode".
+ * In this mode the agent executes the given instructions
+ * multiple times, each time feeding the previous result
+ * back as the next instruction. This demonstrates a very
+ * simple form of self-adaptation.
+ */
+export async function runJulesSelfMode(
+    executor: WebAgentExecutor,
+    initialInstructions: string,
+    iterations = 3,
+): Promise<string> {
+    let instructions = initialInstructions;
+    let result = '';
+    for (let i = 0; i < iterations; i++) {
+        webAgentLog.info(`Jules self mode iteration ${i + 1}`);
+        result = await executor.run(instructions);
+        instructions = `Continue with: ${result}`;
+    }
+    return result;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { createServer } from './screenshotter_server.js';
 import { webAgentLog } from './utils.js';
 import { HTML_CURRENT_PAGE_PREFIX } from './consts.js';
 import { CostHandler } from './cost_handler.js';
+import { runJulesSelfMode } from './jules_self_mode.js';
 
 const LIVE_VIEW_URL = process.env.ACTOR_WEB_SERVER_URL ? process.env.ACTOR_WEB_SERVER_URL : 'http://localhost:4000';
 const RECORDING_PATH = 'recording.mp4';
@@ -27,6 +28,8 @@ const {
     proxyConfiguration,
     openaiApiKey,
     model = 'gpt-3.5-turbo-16k',
+    julesSelfMode = false,
+    julesIterations = 3,
 } = await Actor.getInput() as Input;
 
 if (!process.env.OPENAI_API_KEY && !openaiApiKey) {
@@ -151,7 +154,12 @@ const finalInstructions = startUrl
     ? `Open url ${startUrl} and continue with ${instructions}`
     : instructions;
 webAgentLog.info(`Starting agent with instructions: ${finalInstructions}`);
-const result = await executor.run(finalInstructions);
+let result: string;
+if (julesSelfMode) {
+    result = await runJulesSelfMode(executor, finalInstructions, julesIterations);
+} else {
+    result = await executor.run(finalInstructions);
+}
 const costs = costHandler.getTotalCost();
 webAgentLog.info(`Agent finished its work.`, { costUSD: costs.usd });
 webAgentLog.info(result);


### PR DESCRIPTION
## Summary
- add a simple `runJulesSelfMode` helper
- extend input schema with `julesSelfMode` and iteration count
- allow main script to run in self mode when enabled
- document the new option in the README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68631a8be720832f915b373d98fa711b

## Summary by Sourcery

Add a self-adapting Jules self mode that reruns the agent instructions in a loop based on user-provided flags

New Features:
- Introduce a Jules self mode with a runJulesSelfMode helper to loop agent execution for a configurable number of iterations

Enhancements:
- Extend the actor input schema with julesSelfMode and julesIterations and update the main script to conditionally use the new self mode

Documentation:
- Document the Jules self mode and its iterations option in the README