### PR TITLE
Add Gemini bot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ The cost depends on the model you are using and the action browser process. The 
 **Cost of the running browser**
 
 The Web Agent uses a headless browser. The cost of the browser is based on the amount of time it takes to run the Agent. You can find information about the cost on the [pricing page](https://apify.com/pricing).
+
+## 🤖 Gemini bot
+
+This repository also includes a simple script that uses Google's Gemini model to answer questions about the project. Provide your `GOOGLE_API_KEY` environment variable and run:
+
+```bash
+npm run gemini-bot -- path/to/project "What does this project do?"
+```
+
+The script loads the `README.md` from the specified project path and uses it as context for the Gemini model.

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
 		"express": "^4.18.2",
 		"gpt-3-encoder": "^1.1.4",
 		"langchain": "^0.0.147",
-		"langsmith": "^0.0.41",
-		"puppeteer": "*",
+        "langsmith": "^0.0.41",
+        "@google/generative-ai": "^0.3.0",
+        "puppeteer": "*",
 		"puppeteer-screen-recorder": "^2.1.2",
 		"zod": "^3.22.2"
 	},
@@ -36,9 +37,10 @@
 		"start:dev": "ts-node-esm -T src/main.ts",
 		"build": "tsc",
 		"lint": "eslint ./src --ext .ts",
-		"lint:fix": "eslint ./src --ext .ts --fix",
-		"test": "jest"
-	},
+                "lint:fix": "eslint ./src --ext .ts --fix",
+                "test": "jest",
+                "gemini-bot": "ts-node-esm src/gemini_bot.ts"
+        },
 	"author": "It's not you it's me",
 	"license": "ISC"
 }

--- a/src/gemini_bot.ts
+++ b/src/gemini_bot.ts
@@ -1,0 +1,39 @@
+import { readFile } from 'fs/promises';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+async function loadReadme(path: string): Promise<string> {
+    try {
+        return await readFile(`${path}/README.md`, 'utf-8');
+    } catch {
+        return '';
+    }
+}
+
+async function main() {
+    const projectPath = process.argv[2] || '.';
+    const question = process.argv.slice(3).join(' ') || 'Explain this project.';
+    const apiKey = process.env.GOOGLE_API_KEY;
+    if (!apiKey) throw new Error('GOOGLE_API_KEY env variable is required');
+
+    const readme = await loadReadme(projectPath);
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+
+    const systemPrompt = readme
+        ? `You are a helpful assistant. Use the following README to answer questions:\n${readme}`
+        : 'You are a helpful assistant for the project.';
+
+    const chat = model.startChat({
+        history: [
+            { role: 'system', parts: [{ text: systemPrompt }] },
+        ],
+    });
+
+    const result = await chat.sendMessage(question);
+    console.log(result.response.text());
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Gemini powered helper script `gemini_bot.ts`
- update `package.json` with dependency and npm script
- document how to run the Gemini bot

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fad6cb2e8832faf79d153d05a9686