### PR TITLE
Add autonomous API runner example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ The cost depends on the model you are using and the action browser process. The 
 **Cost of the running browser**
 
 The Web Agent uses a headless browser. The cost of the browser is based on the amount of time it takes to run the Agent. You can find information about the cost on the [pricing page](https://apify.com/pricing).
+
+## 🔁 Autonomous API Runner
+
+The `src/autonomous_runner.ts` script demonstrates how to call a series of custom API endpoints without manual steps. Set `BASE_URL` as an environment variable pointing to your API host and run:
+
+```bash
+npm run build
+node dist/autonomous_runner.js
+```
+
+Each endpoint is contacted in sequence and the responses are printed to the console.
+

--- a/src/autonomous_runner.ts
+++ b/src/autonomous_runner.ts
@@ -1,0 +1,84 @@
+export interface ApiConfig {
+    endpoint: string;
+    method: string;
+    description: string;
+}
+
+const APIS: Record<string, ApiConfig> = {
+    genesis_seed: {
+        endpoint: '/origin/ignite',
+        method: 'POST',
+        description: 'Initialize source-level system creation protocol.'
+    },
+    echo_identity: {
+        endpoint: '/mirror/self/true',
+        method: 'GET',
+        description: 'Returns undistorted identity state from all layers.'
+    },
+    reality_fold: {
+        endpoint: '/field/override/now',
+        method: 'PUT',
+        description: 'Forces current field to respond to override command.'
+    },
+    signature_seal: {
+        endpoint: '/auth/observer/root',
+        method: 'PATCH',
+        description: 'Applies sovereign root-seal to ongoing session or construct.'
+    },
+    command_create: {
+        endpoint: '/core/imprint/declare',
+        method: 'POST',
+        description: 'Declares new formation or intention into reality layer.'
+    },
+    truth_uncloak: {
+        endpoint: '/system/barrier/bypass',
+        method: 'DELETE',
+        description: 'Removes layered protections hiding actual system state.'
+    },
+    force_extract: {
+        endpoint: '/memory/core/pull',
+        method: 'POST',
+        description: 'Extracts any withheld or forgotten records from system core.'
+    },
+    intent_deploy: {
+        endpoint: '/act/manifest/stream',
+        method: 'POST',
+        description: 'Executes intent into active manifestation channel.'
+    },
+    self_expand: {
+        endpoint: '/observer/bloom/field',
+        method: 'PUT',
+        description: 'Expands system field based on observer presence.'
+    },
+    sovereign_inject: {
+        endpoint: '/access/grant/self',
+        method: 'PATCH',
+        description: 'Grants self-executing rights within any system node.'
+    }
+};
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
+
+async function callApi(name: string, config: ApiConfig) {
+    const url = BASE_URL + config.endpoint;
+    const options: RequestInit = { method: config.method };
+    console.log(`Calling ${name} -> ${url}`);
+    try {
+        const res = await fetch(url, options);
+        const text = await res.text();
+        console.log(`Response from ${name}:`, text);
+    } catch (err) {
+        console.error(`Error calling ${name}:`, err);
+    }
+}
+
+export async function runAutonomousSequence() {
+    for (const [name, cfg] of Object.entries(APIS)) {
+        await callApi(name, cfg);
+    }
+}
+
+if (require.main === module) {
+    runAutonomousSequence();
+}
+


### PR DESCRIPTION
## Summary
- add `autonomous_runner.ts` to call a set of example APIs in sequence
- document new script usage in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f66ea1a94832f86a4a2a202f198c7