### PR TITLE
Add unit tests for web agent functions

### DIFF
--- a/test/agent_actions.test.ts
+++ b/test/agent_actions.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from '@jest/globals';
+import { goToUrl, clickElement, fillForm } from '../src/agent_actions.js';
+import { HTML_CURRENT_PAGE_PREFIX, UNIQUE_ID_ATTRIBUTE } from '../src/consts.js';
+
+jest.mock('../src/shrink_html.js', () => ({
+    tagAllElementsOnPage: jest.fn(),
+    shrinkHtmlForWebAutomation: jest.fn(async () => '<html/>'),
+}));
+
+jest.mock('../src/tokens.js', () => ({
+    maybeShortsTextByTokenLength: jest.fn((t: string) => t),
+}));
+
+jest.mock('crawlee', () => ({
+    utils: { puppeteer: { closeCookieModals: jest.fn() } },
+}));
+
+const { tagAllElementsOnPage } = require('../src/shrink_html.js');
+const { maybeShortsTextByTokenLength } = require('../src/tokens.js');
+const { utils } = require('crawlee');
+
+const createPage = () => ({
+    goto: jest.fn(),
+    waitForNavigation: jest.fn(),
+    url: jest.fn(() => 'http://example.com'),
+    evaluate: jest.fn(),
+    keyboard: { press: jest.fn() },
+    $: jest.fn(),
+});
+
+describe('agent actions', () => {
+    test('goToUrl navigates and returns page HTML', async () => {
+        const page = createPage();
+        const result = await goToUrl({ page }, { url: 'http://example.com' });
+        expect(page.goto).toHaveBeenCalledWith('http://example.com');
+        expect(tagAllElementsOnPage).toHaveBeenCalledWith(page, UNIQUE_ID_ATTRIBUTE);
+        expect(result).toBe(`Previous action was: go_to_url, ${HTML_CURRENT_PAGE_PREFIX} <html/>`);
+    });
+
+    test('clickElement clicks by gid', async () => {
+        const element = { click: jest.fn() };
+        const page = createPage();
+        page.$ = jest.fn((selector: string) => selector === 'a[gid="1"]' ? element : null);
+        const result = await clickElement({ page }, { text: 'Link', gid: 1, tagName: 'a' });
+        expect(page.$).toHaveBeenCalledWith('a[gid="1"]');
+        expect(element.click).toHaveBeenCalled();
+        expect(result).toBe(`Previous action was: click_element, ${HTML_CURRENT_PAGE_PREFIX} <html/>`);
+    });
+
+    test('clickElement throws when element missing', async () => {
+        const page = createPage();
+        await expect(clickElement({ page }, { text: 'Missing', gid: 2, tagName: 'a' })).rejects.toThrow('Element not found');
+        expect(utils.puppeteer.closeCookieModals).not.toHaveBeenCalled();
+    });
+
+    test('fillForm fills inputs and submits', async () => {
+        const input = { type: jest.fn() };
+        const button = { click: jest.fn() };
+        const page = createPage();
+        page.$ = jest.fn((selector: string) => {
+            if (selector === `[${UNIQUE_ID_ATTRIBUTE}="1"]`) return input;
+            if (selector === 'button[type="submit"]') return button;
+            return null;
+        });
+        const formData = [{ gid: 1, value: ' test ' }];
+        const result = await fillForm({ page }, { formData });
+        expect(input.type).toHaveBeenCalledWith('test');
+        expect(button.click).toHaveBeenCalled();
+        expect(result).toBe(`Previous action was: fill_form_and_submit, ${HTML_CURRENT_PAGE_PREFIX} <html/>`);
+    });
+});

--- a/test/agent_executor.test.ts
+++ b/test/agent_executor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from '@jest/globals';
+import { WebAgentExecutor } from '../src/agent_executor.js';
+
+const createAgent = () => ({
+    inputKeys: ['input'],
+    returnValues: ['output'],
+    _agentActionType: () => 'single',
+    plan: jest.fn()
+        .mockResolvedValueOnce({ tool: 'test', toolInput: 'foo', log: '' })
+        .mockResolvedValueOnce({ returnValues: { output: 'done' }, log: '' }),
+    prepareForOutput: jest.fn(async (r) => ({ prepared: true })),
+    returnStoppedResponse: jest.fn(),
+});
+
+const tool = { name: 'test', call: jest.fn(async () => 'tool-result'), returnDirect: false };
+
+
+describe('WebAgentExecutor workflow', () => {
+    test('runs agent plan and updates previous step', async () => {
+        const agent = createAgent();
+        const updatePreviousStepMethod = jest.fn((s) => ({ ...s, observation: `${s.observation}-updated` }));
+        const executor = new WebAgentExecutor({ agent, tools: [tool], updatePreviousStepMethod, returnIntermediateSteps: true });
+        const result = await executor.call({ input: 'hello' });
+        expect(agent.plan).toHaveBeenCalledTimes(2);
+        expect(tool.call).toHaveBeenCalledWith('foo', undefined);
+        expect(result.output).toBe('done');
+        expect(result.intermediateSteps[0].observation).toBe('tool-result-updated');
+    });
+});


### PR DESCRIPTION
## Summary
- test goToUrl, clickElement and fillForm in agent_actions
- test WebAgentExecutor workflow

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687576b5617c832fb8a8082b999f16ce

## Summary by Sourcery

Add comprehensive unit tests for web agent actions and the WebAgentExecutor workflow

Tests:
- Test goToUrl, clickElement, and fillForm functions to verify navigation, element interaction, and form submission
- Test WebAgentExecutor execution flow to validate planning, tool invocation, and intermediate step updates