### PR TITLE
Fix screenshot extension in captureAndSaveScreenshot

### DIFF
--- a/src/agent_actions.ts
+++ b/src/agent_actions.ts
@@ -155,8 +155,10 @@ export async function captureAndSaveScreenshot(context: AgentBrowserContext, { f
     const key = filename || 'screenshot';
     const kvs = await Actor.openKeyValueStore();
     await utils.puppeteer.saveSnapshot(page, { key, saveHtml });
-    webAgentLog.info(`Screenshot saved, you can check it ${kvs.getPublicUrl(key)}.jpeg .`, {
-        screenshotUrl: `${kvs.getPublicUrl(key)}.jpg`,
+    const screenshotExtension = '.jpg';
+    const screenshotUrl = `${kvs.getPublicUrl(key)}${screenshotExtension}`;
+    webAgentLog.info(`Screenshot saved, you can check it ${screenshotUrl} .`, {
+        screenshotUrl,
         htmlUrl: saveHtml && `${kvs.getPublicUrl(key)}.html`,
     });
     return 'Screenshot saved';


### PR DESCRIPTION
## Summary
- ensure captureAndSaveScreenshot uses the correct file extension for snapshots

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ace19f14d8832fa78f0529859b1897

## Summary by Sourcery

Bug Fixes:
- Fix mismatch between .jpeg and .jpg in screenshot URLs by appending the correct .jpg extension.