### PR TITLE
feat: add sandbox metrics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,18 @@ node dist/autonomous_runner.js
 
 Each endpoint is contacted in sequence and the responses are printed to the console.
 
+
+## 📈 Sandbox Metrics
+
+Containers can optionally collect lightweight runtime metrics. Metrics are
+recorded as simple key-value pairs and can be written either to a JSON file
+or directly to stdout.
+
+Set the `SANDBOX_METRICS_PATH` environment variable to enable metrics
+collection:
+
+- `SANDBOX_METRICS_PATH=/path/to/metrics.json` – write metrics to a file.
+- `SANDBOX_METRICS_PATH=stdout` – print metrics as JSON to stdout.
+
+Leave `SANDBOX_METRICS_PATH` unset to disable metrics collection if you do
+not wish to collect data or want to avoid the overhead.

--- a/aggregate_results.py
+++ b/aggregate_results.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Aggregate metrics produced by containers.
+
+This script scans provided container result directories for a
+``metrics.json`` file produced by :class:`SandboxMetrics` and
+merges the collected metrics into a single JSON report printed to
+stdout.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+
+def _load_metrics(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with path.open(encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError:
+        return {"error": f"invalid json in {path}"}
+
+
+def main() -> None:
+    report: Dict[str, Any] = {"containers": {}}
+    for dir_arg in sys.argv[1:]:
+        container = Path(dir_arg)
+        metrics = _load_metrics(container / "metrics.json")
+        if metrics is not None:
+            report["containers"][container.name] = metrics
+    json.dump(report, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/metrics/sandbox_metrics.ts
+++ b/src/metrics/sandbox_metrics.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+
+export interface SandboxMetricsOptions {
+    /**
+     * Path to the metrics output file. Set to "stdout" to write to STDOUT.
+     * If undefined, metrics collection is disabled.
+     */
+    outputPath?: string;
+}
+
+/**
+ * Lightweight metrics helper that containers can use to collect
+ * key-value metrics and write them either to a JSON file or stdout.
+ *
+ * Metrics collection can be enabled by providing an output path.
+ * Set `SANDBOX_METRICS_PATH` environment variable to either a file
+ * path or the string "stdout" to enable collection. If the variable
+ * is not set, metrics recording is disabled.
+ */
+export class SandboxMetrics {
+    private metrics: Record<string, unknown> = {};
+
+    constructor(private readonly options: SandboxMetricsOptions = {}) {}
+
+    /**
+     * Create a metrics instance using environment variables.
+     *
+     * If `SANDBOX_METRICS_PATH` is not defined the instance will be
+     * disabled and calls to {@link record} and {@link flush} will be no-ops.
+     */
+    static fromEnv(): SandboxMetrics {
+        const outputPath = process.env.SANDBOX_METRICS_PATH;
+        return new SandboxMetrics({ outputPath });
+    }
+
+    /**
+     * Whether metrics collection is enabled.
+     */
+    get enabled(): boolean {
+        return !!this.options.outputPath;
+    }
+
+    /**
+     * Record a metric value under the provided key. When metrics
+     * collection is disabled this method is a no-op.
+     */
+    record(key: string, value: unknown): void {
+        if (!this.enabled) return;
+        this.metrics[key] = value;
+    }
+
+    /**
+     * Flush collected metrics to the configured destination. When
+     * metrics collection is disabled this method is a no-op.
+     */
+    flush(): void {
+        if (!this.enabled) return;
+        const json = JSON.stringify(this.metrics, null, 2);
+        if (this.options.outputPath === 'stdout') {
+            process.stdout.write(`${json}\n`);
+        } else if (this.options.outputPath) {
+            fs.writeFileSync(this.options.outputPath, json, { encoding: 'utf-8' });
+        }
+    }
+}
+
+export default SandboxMetrics;


### PR DESCRIPTION
## Summary
- add lightweight SandboxMetrics helper for optional JSON/stdout metrics
- aggregate metrics.json files into final report
- document per-container metrics toggling via SANDBOX_METRICS_PATH

## Testing
- `npm run lint` *(fails: Missing trailing comma)*
- `npx eslint src/metrics/sandbox_metrics.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b230af9248832f9bf245f5ec8b185d

## Summary by Sourcery

Add optional sandbox metrics support by introducing a SandboxMetrics helper for recording runtime metrics, a script to aggregate per-container metrics files, and corresponding documentation updates.

New Features:
- Introduce SandboxMetrics class to record and flush key-value metrics to a JSON file or stdout based on SANDBOX_METRICS_PATH
- Add aggregate_results.py script to merge individual metrics.json files from container result directories into a consolidated JSON report

Documentation:
- Document sandbox metrics configuration and usage in README under the SANDBOX_METRICS_PATH environment variable