### PR TITLE
Add canonicalization utility for ledger artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ npm test
 ```
 
 
+## 🔏 Canonicalizing ledger entries
+
+When you need to normalize ledger updates before hashing or signing them, use the bundled canonicalization utility. It produces
+deterministic text output, a SHA-256 digest, and (optionally) a detached GPG signature so you can append the result to
+`ledger/LEGAL_MASTER_LOG.txt` with confidence.
+
+See [docs/canonicalization.md](docs/canonicalization.md) for the canonicalization rules and usage examples.
+
+
 ## 📱 Integrating Scriptable with Shortcuts
 For instructions on connecting the Scriptable app with iOS Shortcuts, see [docs/scriptable-shortcuts.md](docs/scriptable-shortcuts.md).
 

--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -1,0 +1,52 @@
+# Canonicalization and Proof-of-Execution Artifacts
+
+This project now includes a lightweight utility that transforms arbitrary text into a deterministic, canonical representation, computes a SHA-256 digest, and optionally emits a GPG detached signature. These artifacts can then be appended to the ledger workflow described in the Codex mission skeleton.
+
+## Canonicalization rules
+
+The `canonicalize` utility enforces the following rules:
+
+1. Byte Order Marks (BOM) are stripped from the beginning of the file.
+2. Windows (`CRLF`) and classic Mac (`CR`) line endings are normalized to Unix (`LF`).
+3. Trailing whitespace on each line is removed.
+4. Multiple consecutive blank lines are collapsed to a single blank line.
+5. The canonical form always ends with a single trailing newline.
+
+These heuristics intentionally preserve paragraph separation while eliminating incidental formatting differences that would otherwise produce divergent hashes.
+
+## Usage
+
+```bash
+npm run canonicalize -- path/to/input.txt
+```
+
+By default this creates three sibling files next to the input:
+
+- `input.canonical.txt` – normalized content
+- `input.canonical.txt.sha256` – SHA-256 digest in the format `<hash>  <filename>`
+- `input.canonical.txt.asc` – ASCII-armored detached signature (requires `gpg` and a configured default key)
+
+### Optional flags
+
+- `--canonical <path>`: override the canonical output file path
+- `--sha <path>`: override the SHA file path
+- `--signature <path>`: override the signature file path
+- `--gpg-key <key-id>`: select a specific GPG key for signing
+- `--no-sign`: skip the signing step entirely
+
+Example producing artifacts in a custom directory and skipping signatures:
+
+```bash
+npm run canonicalize -- ./notes/draft.txt --canonical ./artifacts/draft.canonical.txt --sha ./artifacts/draft.sha --no-sign
+```
+
+## Integrating with the ledger workflow
+
+The GitHub Actions workflow from the mission skeleton can invoke this utility after deployment to normalize the Proof-of-Execution payload before committing it to `ledger/LEGAL_MASTER_LOG.txt`. A typical pattern is:
+
+1. Generate your ledger entry (e.g., JSON containing deployment metadata).
+2. Write the entry to a temporary file.
+3. Run the canonicalizer to produce `canonical.txt`, `canonical.txt.sha256`, and `canonical.txt.asc`.
+4. Append the canonical text to the ledger and stash the accompanying `.sha256` and `.asc` artifacts for auditing.
+
+This approach keeps ledger entries reproducible while providing a cryptographic audit trail you can anchor to your preferred transparency layer (signed git tags, IPFS, blockchain anchoring, etc.).

--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
 	},
 	"scripts": {
 		"start": "npm run start:dev",
-		"start:prod": "node dist/main.js",
-		"start:dev": "ts-node-esm -T src/main.ts",
-		"build": "tsc",
-		"lint": "eslint ./src --ext .ts",
-		"lint:fix": "eslint ./src --ext .ts --fix",
-		"test": "node --test"
+        "start:prod": "node dist/main.js",
+        "start:dev": "ts-node-esm -T src/main.ts",
+        "build": "tsc",
+        "lint": "eslint ./src --ext .ts",
+        "lint:fix": "eslint ./src --ext .ts --fix",
+        "test": "node --test",
+        "canonicalize": "node ./src/canonicalize.js"
 	},
 	"author": "It's not you it's me",
 	"license": "ISC"

--- a/src/canonicalize.js
+++ b/src/canonicalize.js
@@ -1,0 +1,189 @@
+import fs from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export function canonicalizeText(input) {
+    const withoutBom = input.replace(/^\uFEFF/, '');
+    const normalizedLineEndings = withoutBom.replace(/\r\n?/g, '\n');
+    const trimmedLines = normalizedLineEndings
+        .split('\n')
+        .map((line) => line.replace(/\s+$/u, ''));
+
+    const collapsedLines = [];
+    let blankCount = 0;
+    for (const line of trimmedLines) {
+        if (line === '') {
+            blankCount += 1;
+            if (blankCount > 1) {
+                continue;
+            }
+        } else {
+            blankCount = 0;
+        }
+
+        collapsedLines.push(line);
+    }
+
+    let canonical = collapsedLines.join('\n');
+    if (!canonical.endsWith('\n')) {
+        canonical += '\n';
+    }
+
+    return canonical;
+}
+
+async function writeFileEnsuringDir(filePath, content) {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content, 'utf8');
+}
+
+async function signWithGpg({ canonicalPath, signaturePath, gpgKey }) {
+    const args = ['--armor', '--detach-sign', '--output', signaturePath];
+    if (gpgKey) {
+        args.push('--local-user', gpgKey);
+    }
+    args.push(canonicalPath);
+
+    await new Promise((resolve, reject) => {
+        const child = spawn('gpg', args, { stdio: 'inherit' });
+
+        child.on('error', (error) => {
+            if (error.code === 'ENOENT') {
+                reject(new Error('gpg is required to create signatures but was not found in PATH.'));
+                return;
+            }
+            reject(error);
+        });
+
+        child.on('exit', (code) => {
+            if (code === 0) {
+                resolve(undefined);
+            } else {
+                reject(new Error(`gpg exited with code ${code}`));
+            }
+        });
+    });
+}
+
+export async function canonicalizeFile(options) {
+    const { inputPath, canonicalPath, shaPath, signaturePath, gpgKey, sign = true } = options;
+
+    const source = await fs.readFile(inputPath, 'utf8');
+    const canonical = canonicalizeText(source);
+    await writeFileEnsuringDir(canonicalPath, canonical);
+
+    const hash = createHash('sha256').update(canonical, 'utf8').digest('hex');
+    const hashLine = `${hash}  ${path.basename(canonicalPath)}\n`;
+    await writeFileEnsuringDir(shaPath, hashLine);
+
+    if (sign) {
+        await signWithGpg({ canonicalPath, signaturePath, gpgKey });
+    }
+
+    return {
+        canonicalPath,
+        shaPath,
+        signaturePath: sign ? signaturePath : undefined,
+        hash,
+    };
+}
+
+function buildDefaultPaths(inputPath) {
+    const { dir, name } = path.parse(inputPath);
+    const canonicalPath = path.join(dir, `${name}.canonical.txt`);
+    return {
+        canonicalPath,
+        shaPath: `${canonicalPath}.sha256`,
+        signaturePath: `${canonicalPath}.asc`,
+    };
+}
+
+function parseArgs(argv) {
+    const args = argv.slice(2);
+    if (args.length === 0) {
+        throw new Error('Missing input file. Usage: canonicalize <input> [--canonical path] [--sha path] [--signature path] [--gpg-key key-id] [--no-sign]');
+    }
+
+    const inputPath = args[0];
+    const defaults = buildDefaultPaths(inputPath);
+
+    const options = {
+        inputPath,
+        canonicalPath: defaults.canonicalPath,
+        shaPath: defaults.shaPath,
+        signaturePath: defaults.signaturePath,
+        sign: true,
+        gpgKey: undefined,
+    };
+
+    for (let i = 1; i < args.length; i += 1) {
+        const arg = args[i];
+        if (arg === '--canonical') {
+            i += 1;
+            if (i >= args.length) throw new Error('--canonical requires a value');
+            options.canonicalPath = args[i];
+        } else if (arg === '--sha') {
+            i += 1;
+            if (i >= args.length) throw new Error('--sha requires a value');
+            options.shaPath = args[i];
+        } else if (arg === '--signature') {
+            i += 1;
+            if (i >= args.length) throw new Error('--signature requires a value');
+            options.signaturePath = args[i];
+        } else if (arg === '--gpg-key') {
+            i += 1;
+            if (i >= args.length) throw new Error('--gpg-key requires a value');
+            options.gpgKey = args[i];
+        } else if (arg === '--no-sign') {
+            options.sign = false;
+        } else {
+            throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+
+    if (options.sign && !options.signaturePath) {
+        throw new Error('Signature path must be provided when signing is enabled.');
+    }
+
+    return options;
+}
+
+async function runCli() {
+    try {
+        const { inputPath, canonicalPath, shaPath, signaturePath, sign, gpgKey } = parseArgs(process.argv);
+        const result = await canonicalizeFile({
+            inputPath,
+            canonicalPath,
+            shaPath,
+            signaturePath,
+            sign,
+            gpgKey,
+        });
+
+        process.stdout.write(`Canonical file written to ${result.canonicalPath}\n`);
+        process.stdout.write(`SHA-256 written to ${result.shaPath}\n`);
+        if (result.signaturePath) {
+            process.stdout.write(`Signature written to ${result.signaturePath}\n`);
+        } else {
+            process.stdout.write('Signature skipped.\n');
+        }
+    } catch (error) {
+        process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+        process.exitCode = 1;
+    }
+}
+
+const isMainModule = (() => {
+    try {
+        return fileURLToPath(import.meta.url) === fileURLToPath(process.argv[1]);
+    } catch {
+        return false;
+    }
+})();
+
+if (isMainModule) {
+    runCli();
+}

--- a/test/canonicalize.test.js
+++ b/test/canonicalize.test.js
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { canonicalizeText } from '../src/canonicalize.js';
+
+const sample = '\ufeffLine with spaces   \r\n' +
+    '\r\n' +
+    'Second line\t\r\n' +
+    'Third line\r\n' +
+    '\r\n' +
+    '\r\n';
+
+test('canonicalizeText normalizes whitespace, line endings, and blank lines', () => {
+    const canonical = canonicalizeText(sample);
+    assert.equal(canonical, 'Line with spaces\n\nSecond line\nThird line\n');
+});
+
+test('canonicalizeText ensures trailing newline', () => {
+    const canonical = canonicalizeText('No newline at end');
+    assert.equal(canonical, 'No newline at end\n');
+});


### PR DESCRIPTION
## Summary
- add a canonicalization CLI that normalizes text, emits SHA-256 digests, and optionally signs with GPG
- document canonicalization workflow integration and expose an npm script for the tool
- cover the canonicalization rules with unit tests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ed42a69d48832faab4d28ed6fe8aeb

## Summary by Sourcery

Introduce a new canonicalization utility for ledger artifacts that produces deterministic text output, a SHA-256 checksum, and optional GPG signatures, along with documentation and tests to support its integration into the existing workflow.

New Features:
- Implement a canonicalization CLI that normalizes ledger text, emits a SHA-256 digest, and optionally generates a GPG detached signature
- Add a 'canonicalize' npm script to invoke the canonicalization utility

Documentation:
- Document canonicalization workflow, usage examples, and rules in README.md and docs/canonicalization.md

Tests:
- Add unit tests for canonicalization rules covering BOM stripping, line ending normalization, whitespace trimming, blank line collapsing, and trailing newline enforcement